### PR TITLE
goreleaser: add linux/ppc64le to releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,7 @@ builds:
       - '386'
       - arm
       - arm64
+      - ppc64le
     ignore:
       - goos: linux
         goarch: amd64


### PR DESCRIPTION
As requested by OSU's OSS lab, we add a target for ppc64le on Linux for the plugin.