### PR TITLE
Add retry logic to fix the server terminate failed issue

### DIFF
--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -158,14 +158,9 @@ func (s *StepRunSourceServer) Cleanup(state multistep.StateBag) {
 	ui.Say(fmt.Sprintf("Terminating the source server: %s ...", s.server.ID))
 	for {
 		if config.ForceDelete {
-			if err = servers.ForceDelete(computeClient, s.server.ID).ExtractErr(); err != nil {
-				ui.Error(fmt.Sprintf("Error terminating server, may still be around: %s", err))
-				return
-			}
+			err = servers.ForceDelete(computeClient, s.server.ID).ExtractErr()
 		} else {
-			if err = servers.Delete(computeClient, s.server.ID).ExtractErr(); err != nil {
-				ui.Error(fmt.Sprintf("Error terminating server, may still be around: %s", err))
-				return
+			err = servers.Delete(computeClient, s.server.ID).ExtractErr()
 			}
 		}
 

--- a/builder/openstack/step_run_source_server.go
+++ b/builder/openstack/step_run_source_server.go
@@ -161,7 +161,6 @@ func (s *StepRunSourceServer) Cleanup(state multistep.StateBag) {
 			err = servers.ForceDelete(computeClient, s.server.ID).ExtractErr()
 		} else {
 			err = servers.Delete(computeClient, s.server.ID).ExtractErr()
-			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
In our openstack environment, we randomly get the error while terminating the server on the end of packer build.
It causes many useless VMs existing in our openstack.
The error is like this:
![error](https://user-images.githubusercontent.com/14901481/220543441-bf5c744a-c7bc-411a-bc69-7a9893f2c95b.png)
The following is the stack trace from OCP service side when the issue happened.
```
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions [req-965cda1d-a06d-42f6-ade4-4067bcf951ad f2540ed3657741ad9485a440c24aa45a f361dec2c1bd43789b6f5a96f3f252ba - default default] Unexpected exception in API method
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions Traceback (most recent call last):
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions   File "/usr/lib/python2.7/site-packages/nova/api/openstack/extensions.py", line 338, in wrapped
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions     return f(*args, **kwargs)
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions   File "/usr/lib/python2.7/site-packages/nova/api/openstack/compute/deferred_delete.py", line 64, in _force_delete
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions     self.compute_api.force_delete(context, instance)
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions   File "/usr/lib/python2.7/site-packages/nova/compute/api.py", line 166, in inner
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions     return function(self, context, instance, *args, **kwargs)
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions   File "/usr/lib/python2.7/site-packages/nova/compute/api.py", line 139, in inner
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions     method=f.__name__)
2023-02-08 03:07:36.912 5493 ERROR nova.api.openstack.extensions InstanceInvalidState: Instance 983e2da3-fcaa-45cb-ba2d-1aa21bf9ec37 in task_state image_uploading. Cannot force_delete while the instance is in this state. 
```
According to the logic of [packer-plugin-openstack](https://github.com/hashicorp/packer-plugin-openstack/blob/ddf068815e36b0925ef06e8c3aea2a5caa8d15a9/builder/openstack/step_create_image.go#L145), when the status of the image has become `active`, then packer will try to remove the temporary VM immediately, if the remove action fails, then the error will happen.

From the stack trace, when the status of the image has been changed to `active`, the image uploading task of the VM hasn't been finished.

Then the VM delete action will be failed, and OCP service will report: `Internal Server Error`, and the HTTP error code is 500.

In this PR, a retry logic has been added to detect whether it meets `Internal Server Error`, if so, it will have a retry up to 20 seconds.