### PR TITLE
Add pre-validate step to check if the image name has already been used

### DIFF
--- a/builder/openstack/builder.go
+++ b/builder/openstack/builder.go
@@ -98,6 +98,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 
 	// Build the steps
 	steps := []multistep.Step{
+		&StepPreValidate{
+			ForceImageName: b.config.PackerConfig.PackerForce,
+		},
 		&StepLoadFlavor{
 			Flavor: b.config.Flavor,
 		},

--- a/builder/openstack/step_pre_validate.go
+++ b/builder/openstack/step_pre_validate.go
@@ -1,0 +1,71 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package openstack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type StepPreValidate struct {
+	ForceImageName    bool
+}
+
+func (s *StepPreValidate) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	config := state.Get("config").(*Config)
+	ui := state.Get("ui").(packersdk.Ui)
+
+	client, err := config.imageV2Client()
+	if err != nil {
+		err := fmt.Errorf("error creating image client: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if s.ForceImageName {
+		ui.Say("ForceImageName flag found, skipping prevalidating Image Name")
+		return multistep.ActionContinue
+	}
+
+	ui.Say(fmt.Sprintf("Prevalidating Image Name: %s", config.ImageName))
+
+	listOpts := images.ListOpts{
+		Name: config.ImageName,
+	}	
+
+	var imageList []images.Image
+	err = images.List(client, listOpts).EachPage(func(page pagination.Page) (bool, error) {
+		imageBatch, err := images.ExtractImages(page)
+		if err != nil {
+			return false, err
+		}
+		imageList = append(imageList, imageBatch...)
+		return true, nil
+	})
+
+	if err != nil {
+		err := fmt.Errorf("Error querying image: %s", err)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt
+	}
+
+	if len(imageList) > 0 {
+		err := fmt.Errorf("Error: Image Name: '%s' has already been used", config.ImageName)
+		state.Put("error", err)
+		ui.Error(err.Error())
+		return multistep.ActionHalt		
+	}
+
+	return multistep.ActionContinue
+}
+
+func (s *StepPreValidate) Cleanup(state multistep.StateBag) {
+}


### PR DESCRIPTION
For the packer image build on the Openstack platform, there is a lack of a pre-validate step for the image name like in the [packer-plugin-amazon](https://github.com/hashicorp/packer-plugin-amazon/blob/main/builder/common/step_pre_validate.go) plugin, resulting in the name of the built image often being repeated like this:
![image](https://github.com/hashicorp/packer-plugin-openstack/assets/130132306/09794cd6-6910-4aef-b5d0-375c5afc2987)
It always causes some confusion when using image.

In this PR, a pre-validate step has been added to check if the image name has already been used. If the image name has already been used, an error will be output. "packer_force" parameter can be used to skip the pre-validate step when it is set to 'true' like the logic of [packer-plugin-amazon](https://github.com/hashicorp/packer-plugin-amazon/blob/877a7b15d179e840e1e3f191644c0eeb362551cb/builder/common/step_pre_validate.go#L82) plugin.
