### PR TITLE
Fix dead loop while the status of volume is error

### DIFF
--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -6,6 +6,7 @@ package openstack
 import (
 	"context"
 	"fmt"
+
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -82,7 +82,6 @@ func (s *StepCreateVolume) Run(ctx context.Context, state multistep.StateBag) mu
 		err := fmt.Errorf("Error waiting for volume: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
-
 		return multistep.ActionHalt
 	}
 

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -114,7 +114,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 	// Delete the volume in any status if exists.
 	err = volumes.Delete(blockStorageClient, s.volumeID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
-		ui.Error(fmt.Sprintf(
+		ui.Error(fmt.Sprintf("Error cleaning up volume %q: %s. This may need manual deletion.", s.volumeID, err))
 			"Error cleaning up volume. Please delete the volume manually: %s", s.volumeID))
 	}
 }

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -6,7 +6,6 @@ package openstack
 import (
 	"context"
 	"fmt"
-
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/hashicorp/packer-plugin-sdk/multistep"
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
@@ -79,9 +78,18 @@ func (s *StepCreateVolume) Run(ctx context.Context, state multistep.StateBag) mu
 	// Wait for volume to become available.
 	ui.Say(fmt.Sprintf("Waiting for volume %s (volume id: %s) to become available...", config.VolumeName, volume.ID))
 	if err := WaitForVolume(blockStorageClient, volume.ID); err != nil {
+		_, ok := err.(*volumeErr)
 		err := fmt.Errorf("Error waiting for volume: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
+		if ok {
+			ui.Say(fmt.Sprintf("Deleting volume: %s ...", volume.ID))
+			err = volumes.Delete(blockStorageClient, volume.ID, volumes.DeleteOpts{}).ExtractErr()
+			if err != nil {
+				ui.Error(fmt.Sprintf(
+					"Error cleaning up volume. Please delete the volume manually: %s", volume.ID))
+			}
+		}
 		return multistep.ActionHalt
 	}
 
@@ -119,7 +127,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	if status != "available" {
+	if status != "available" && status != "error" {
 		ui.Say(fmt.Sprintf(
 			"Waiting for volume %s (volume id: %s) to become available...", s.VolumeName, s.volumeID))
 		if err := WaitForVolume(blockStorageClient, s.volumeID); err != nil {

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -83,10 +83,6 @@ func (s *StepCreateVolume) Run(ctx context.Context, state multistep.StateBag) mu
 		state.Put("error", err)
 		ui.Error(err.Error())
 
-		// The volume ID has created, try to clean up
-		s.doCleanup = true
-		s.volumeID = volume.ID
-
 		return multistep.ActionHalt
 	}
 
@@ -124,7 +120,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	if status != "available" && status != "error" {
+	if status != "available" {
 		ui.Say(fmt.Sprintf(
 			"Waiting for volume %s (volume id: %s) to become available...", s.VolumeName, s.volumeID))
 		if err := WaitForVolume(blockStorageClient, s.volumeID); err != nil {

--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -114,6 +114,7 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 	// Delete the volume in any status if exists.
 	err = volumes.Delete(blockStorageClient, s.volumeID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
-		ui.Error(fmt.Sprintf("Error cleaning up volume %q: %s. This may need manual deletion.", s.volumeID, err))
+		ui.Error(fmt.Sprintf(
+			"Error cleaning up volume %q: %s. This may need manual deletion.", s.volumeID, err))
 	}
 }

--- a/builder/openstack/volume.go
+++ b/builder/openstack/volume.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"errors"
 	"log"
 	"time"
 
@@ -37,6 +38,10 @@ func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID strin
 
 		if status == "available" {
 			return nil
+		}
+
+		if status == "error" {
+			return errors.New("The status of volume is error")
 		}
 
 		log.Printf("Waiting for volume creation status: %s", status)

--- a/builder/openstack/volume.go
+++ b/builder/openstack/volume.go
@@ -18,6 +18,7 @@ func (err *volumeErr) Error() string {
 	return "The status of volume is error"
 }
 
+// WaitForVolume waits for the given volume to become available.
 func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID string) error {
 	maxNumErrors := 10
 	numErrors := 0

--- a/builder/openstack/volume.go
+++ b/builder/openstack/volume.go
@@ -4,7 +4,6 @@
 package openstack
 
 import (
-	"errors"
 	"log"
 	"time"
 
@@ -13,7 +12,12 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 )
 
-// WaitForVolume waits for the given volume to become available.
+type volumeErr struct{}
+
+func (err *volumeErr) Error() string {
+	return "The status of volume is error"
+}
+
 func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID string) error {
 	maxNumErrors := 10
 	numErrors := 0
@@ -41,7 +45,7 @@ func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID strin
 		}
 
 		if status == "error" {
-			return errors.New("The status of volume is error")
+			return &volumeErr{}
 		}
 
 		log.Printf("Waiting for volume creation status: %s", status)

--- a/builder/openstack/volume.go
+++ b/builder/openstack/volume.go
@@ -4,6 +4,7 @@
 package openstack
 
 import (
+	"errors"
 	"log"
 	"time"
 
@@ -11,12 +12,6 @@ import (
 	"github.com/gophercloud/gophercloud/openstack/blockstorage/v3/volumes"
 	"github.com/gophercloud/gophercloud/openstack/imageservice/v2/images"
 )
-
-type volumeErr struct{}
-
-func (err *volumeErr) Error() string {
-	return "The status of volume is error"
-}
 
 // WaitForVolume waits for the given volume to become available.
 func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID string) error {
@@ -46,7 +41,7 @@ func WaitForVolume(blockStorageClient *gophercloud.ServiceClient, volumeID strin
 		}
 
 		if status == "error" {
-			return &volumeErr{}
+			return errors.New("The status of volume is error")
 		}
 
 		log.Printf("Waiting for volume creation status: %s", status)


### PR DESCRIPTION
There is a dead loop bug that while we create a volume successfully, but after that the status of the volume becomes error, because the code https://github.com/hashicorp/packer-plugin-openstack/blob/89e8768ed57bfe6b407b1151a11d0e6533596de6/builder/openstack/volume.go#L21 only check the second return variable err, but it is only related with whether the Openstack API call is OK, but the code doesn't care about the first return variable status which identify the status of volume, if error is nil but status is "error", it will be dead lock.
It can easily be reproduce by set the volume size less than the OS image size, the debug log is following:
<img width="1120" alt="图片" src="https://github.com/hashicorp/packer-plugin-openstack/assets/14901481/a61fcd6e-c889-4013-91e0-164dc64adcd3">
