### PR TITLE
Fix the issue volume based VM deleted twice

### DIFF
--- a/builder/openstack/step_delete_server.go
+++ b/builder/openstack/step_delete_server.go
@@ -26,6 +26,7 @@ func (s *StepDeleteServer) Run(ctx context.Context, state multistep.StateBag) mu
 		state.Put("error", err)
 		return multistep.ActionHalt
 	}
+	state.Put("instance_id", "")
 	return multistep.ActionContinue
 }
 


### PR DESCRIPTION
There is a issue that while build image on volume based VM, the VM will be delete twice
![图片](https://github.com/hashicorp/packer-plugin-openstack/assets/14901481/18d64f46-4767-4a53-a69f-a775c4947a72)
The first "Terminating the source server" comes from https://github.com/hashicorp/packer-plugin-openstack/blob/2e7e2190b73151cbf264fb91d7295c192030ff88/builder/openstack/step_delete_server.go#L24 and the second comes from https://github.com/hashicorp/packer-plugin-openstack/blob/2e7e2190b73151cbf264fb91d7295c192030ff88/builder/openstack/step_run_source_server.go#L148