### PR TITLE
fix: add wait to image creation

### DIFF
--- a/.web-docs/components/builder/openstack/README.md
+++ b/.web-docs/components/builder/openstack/README.md
@@ -317,6 +317,8 @@ builder.
 
 - `use_floating_ip` (bool) - *Deprecated* use `floating_ip` or `floating_ip_pool` instead.
 
+- `image_creation_wait` (int) - Additional wait time in seconds after the image reaches `active` status (default: 0).
+
 <!-- End of code generated from the comments of the RunConfig struct in builder/openstack/run_config.go; -->
 
 

--- a/builder/openstack/builder.hcl2spec.go
+++ b/builder/openstack/builder.hcl2spec.go
@@ -129,6 +129,7 @@ type FlatConfig struct {
 	VolumeAvailabilityZone        *string                 `mapstructure:"volume_availability_zone" required:"false" cty:"volume_availability_zone" hcl:"volume_availability_zone"`
 	OpenstackProvider             *string                 `mapstructure:"openstack_provider" cty:"openstack_provider" hcl:"openstack_provider"`
 	UseFloatingIp                 *bool                   `mapstructure:"use_floating_ip" required:"false" cty:"use_floating_ip" hcl:"use_floating_ip"`
+	ImageCreationWait             *int                    `mapstructure:"image_creation_wait" required:"false" cty:"image_creation_wait" hcl:"image_creation_wait"`
 }
 
 // FlatMapstructure returns a new FlatConfig.
@@ -261,6 +262,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"volume_availability_zone":         &hcldec.AttrSpec{Name: "volume_availability_zone", Type: cty.String, Required: false},
 		"openstack_provider":               &hcldec.AttrSpec{Name: "openstack_provider", Type: cty.String, Required: false},
 		"use_floating_ip":                  &hcldec.AttrSpec{Name: "use_floating_ip", Type: cty.Bool, Required: false},
+		"image_creation_wait":              &hcldec.AttrSpec{Name: "image_creation_wait", Type: cty.Number, Required: false},
 	}
 	return s
 }

--- a/builder/openstack/run_config.go
+++ b/builder/openstack/run_config.go
@@ -177,6 +177,8 @@ type RunConfig struct {
 	OpenstackProvider string `mapstructure:"openstack_provider"`
 	// *Deprecated* use `floating_ip` or `floating_ip_pool` instead.
 	UseFloatingIp bool `mapstructure:"use_floating_ip" required:"false"`
+	// Additional wait time in seconds after the image reaches `active` status (default: 0).
+	ImageCreationWait int `mapstructure:"image_creation_wait" required:"false"`
 
 	sourceImageOpts images.ListOpts
 }

--- a/builder/openstack/step_create_image.go
+++ b/builder/openstack/step_create_image.go
@@ -105,7 +105,7 @@ func (s *stepCreateImage) Run(ctx context.Context, state multistep.StateBag) mul
 
 	// Wait for the image to become ready
 	ui.Say(fmt.Sprintf("Waiting for image %s (image id: %s) to become ready...", config.ImageName, imageId))
-	if err := WaitForImage(ctx, imageClient, imageId); err != nil {
+	if err := WaitForImage(ctx, imageClient, imageId, config.ImageCreationWait); err != nil {
 		err := fmt.Errorf("Error waiting for image: %s", err)
 		state.Put("error", err)
 		ui.Error(err.Error())
@@ -120,7 +120,7 @@ func (s *stepCreateImage) Cleanup(multistep.StateBag) {
 }
 
 // WaitForImage waits for the given Image ID to become ready.
-func WaitForImage(ctx context.Context, client *gophercloud.ServiceClient, imageId string) error {
+func WaitForImage(ctx context.Context, client *gophercloud.ServiceClient, imageId string, imageCreationWait int) error {
 	maxNumErrors := 10
 	numErrors := 0
 
@@ -146,6 +146,16 @@ func WaitForImage(ctx context.Context, client *gophercloud.ServiceClient, imageI
 		}
 
 		if image.Status == "active" {
+			if imageCreationWait > 0 {
+				log.Printf("Additional wait (%d seconds) after image status has changed to active...", imageCreationWait)
+				select {
+				case <-time.After(time.Duration(imageCreationWait) * time.Second):
+					// Timer finished, safe to continue
+				case <-ctx.Done():
+					// User cancelled during the wait, abort immediately
+					return ctx.Err()
+				}
+			}
 			return nil
 		}
 

--- a/docs-partials/builder/openstack/RunConfig-not-required.mdx
+++ b/docs-partials/builder/openstack/RunConfig-not-required.mdx
@@ -96,4 +96,6 @@
 
 - `use_floating_ip` (bool) - *Deprecated* use `floating_ip` or `floating_ip_pool` instead.
 
+- `image_creation_wait` (int) - Additional wait time in seconds after the image reaches `active` status (default: 0).
+
 <!-- End of code generated from the comments of the RunConfig struct in builder/openstack/run_config.go; -->


### PR DESCRIPTION
### Description
In our OpenStack environment we had issues where the image that was being built by this plugin was deleted by the end of the process.  A colleague narrowed the issue down to the possibility that image hadn't completely finished saving when packer had received the notification that it had saved which caused the VM to be deleted and also the image to be deleted too.  

This PR adds a configurable wait to the image saving process in order to allow the underlying processes to finish.  In our testing 5 seconds is enough for the image to be saved correctly.

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #37