### PR TITLE
fix: treat 404 on server delete as success

### DIFF
--- a/builder/openstack/server.go
+++ b/builder/openstack/server.go
@@ -122,6 +122,11 @@ func DeleteServer(state multistep.StateBag, instance string) error {
 			break
 		}
 
+		if _, ok := err.(gophercloud.ErrDefault404); ok {
+			ui.Say(fmt.Sprintf("Server %s is already deleted", instance))
+			return nil
+		}
+
 		if _, ok := err.(gophercloud.ErrDefault500); !ok {
 			err = fmt.Errorf("Error terminating server, may still be around: %s", err)
 			return err


### PR DESCRIPTION
same as in ServerStateRefreshFunc

----

### Description
What code changed, and why?

Handling of 404 responses when trying to delete an instance the second time around. Simpler Version of #127, might be easier to merge? Similar logic is already used in the project at: https://github.com/hashicorp/packer-plugin-openstack/blob/a7e79ff321ff2b425ea8851b43682f9f2bdbcc63/builder/openstack/server.go#L45
