### PR TITLE
Remove redundant square braces for ipv6 with latest sdk version

### DIFF
--- a/builder/openstack/ssh.go
+++ b/builder/openstack/ssh.go
@@ -5,7 +5,6 @@ package openstack
 
 import (
 	"errors"
-	"fmt"
 	"log"
 	"time"
 
@@ -90,21 +89,22 @@ func sshAddrFromPool(s *servers.Server, desired string, sshIPVersion string) str
 		for _, element := range elements {
 			var addr string
 			address := element.(map[string]interface{})
+			address_value := address["addr"].(string)
 			if address["OS-EXT-IPS:type"] == "floating" {
-				addr = address["addr"].(string)
+				addr = address_value
 			} else if sshIPVersion == "4" {
 				if address["version"].(float64) == 4 {
-					addr = address["addr"].(string)
+					addr = address_value
 				}
 			} else if sshIPVersion == "6" {
 				if address["version"].(float64) == 6 {
-					addr = fmt.Sprintf("[%s]", address["addr"].(string))
+					addr = address_value
 				}
 			} else {
 				if address["version"].(float64) == 6 {
-					addr = fmt.Sprintf("[%s]", address["addr"].(string))
+					addr = address_value
 				} else {
-					addr = address["addr"].(string)
+					addr = address_value
 				}
 			}
 


### PR DESCRIPTION
### Description

Until the latest release of plugin, it was using the older SDK version in release 1.1.2 (Feb 29, 2024). In 1.1.3 however the latest SDK version is in use which includes proper handling of ipv6 addresses directly in the SDK itself: https://github.com/hashicorp/packer-plugin-sdk/pull/246/files 

This breaks ipv6 connectivity for openstack plugin because address is returned with square braces around it.

I have kept if/else structure the same to ensure precedence still is given to ipv6 if present and returned first. No logic change.

### Error messages from 1.1.3 using latest plugin sdk showing redundant square braces


> 2025/11/21 09:59:44 packer-plugin-openstack_v1.1.3_x5.0_linux_amd64 plugin: 2025/11/21 09:59:44 [DEBUG] TCP connection to SSH ip/port failed: dial tcp: address [[2a00:1350:2001:211]]:22: missing port in address


### Changes to Security Controls

No changes related to security controls.
