### PR TITLE
fix: use openstack as hcp metadata provider name

### DIFF
--- a/builder/openstack/artifact.go
+++ b/builder/openstack/artifact.go
@@ -65,6 +65,7 @@ func (a *Artifact) State(name string) any {
 			log.Printf("[DEBUG] error encountered when creating a registry image %v", err)
 			return nil
 		}
+		img.ProviderName = "openstack"
 		return img
 
 	}

--- a/builder/openstack/artifact_test.go
+++ b/builder/openstack/artifact_test.go
@@ -70,7 +70,7 @@ func TestArtifactState_StateData(t *testing.T) {
 func TestArtifactState_hcpPackerRegistryMetadata(t *testing.T) {
 	artifact := &Artifact{
 		ImageId:        "foo",
-		BuilderIdValue: "openstack",
+		BuilderIdValue: "mitchellh.openstack",
 		SourceImage:    "bar",
 		Region:         "mordor-7",
 	}


### PR DESCRIPTION

----

### Description
Previously was using the default value which had the `mitchellh.` prefix

To be consistent with other plugin, we need to remove the prefix. (also help with showing the right icon in HCP)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.

