### PR TITLE
Add HCP Ready flag to web metadata

### DIFF
--- a/.web-docs/metadata.hcl
+++ b/.web-docs/metadata.hcl
@@ -7,6 +7,7 @@ integration {
   name = "OpenStack"
   description = "The OpenStack multi-component plugin can be used with HashiCorp Packer to create custom images."
   identifier = "packer/hashicorp/openstack"
+  flags = ["hcp-ready"]
   component {
     type = "builder"
     name = "OpenStack"


### PR DESCRIPTION
### Description
What code changed, and why?

This PR adds the `hcp-ready` flag to the web metadata file to add the "HCP Ready" badge to the web documentation.

### Resolved Issues
If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

N/A

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
### Rollback Plan

If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls

N/A

