### PR TITLE
fix: wait for volume to become available before cleanup deletion

### DIFF
--- a/builder/openstack/step_create_volume.go
+++ b/builder/openstack/step_create_volume.go
@@ -109,9 +109,17 @@ func (s *StepCreateVolume) Cleanup(state multistep.StateBag) {
 		return
 	}
 
-	ui.Say(fmt.Sprintf("Deleting volume: %s ...", s.volumeID))
+	// Wait for the volume to become available before deleting.
+	// After image creation from a volume, Cinder may still be detaching it
+	// (status "uploading"). Deleting in that state returns a 400 error.
+	ui.Say(fmt.Sprintf("Waiting for volume %s to become available...", s.volumeID))
+	if err := WaitForVolume(blockStorageClient, s.volumeID); err != nil {
+		ui.Error(fmt.Sprintf(
+			"Error waiting for volume %s to become available: %s. Attempting deletion anyway.",
+			s.volumeID, err))
+	}
 
-	// Delete the volume in any status if exists.
+	ui.Say(fmt.Sprintf("Deleting volume: %s ...", s.volumeID))
 	err = volumes.Delete(blockStorageClient, s.volumeID, volumes.DeleteOpts{}).ExtractErr()
 	if err != nil {
 		ui.Error(fmt.Sprintf(


### PR DESCRIPTION
Fixes #123

  ## Problem

  When `use_blockstorage_volume` is enabled, the `Cleanup()` method in StepCreateVolume` attempts to delete the volume immediately after the has been created. However, Cinder may still be detaching the (status "uploading"), causing deletion to fail with a 400 error:

      Volume status must be available or error or error_restoring or or error_managing and must not be migrating, belong to a group, have snapshots, awaiting a transfer, be disassociated from snapshots after volume transfer.

  This leaves orphaned volumes that require manual cleanup.

  ## Fix

  Added a call to the existing `WaitForVolume()` function before attempting deletion in `Cleanup()`. This polls until the volume reaches "available" or "error" status, which is consistent with how `Run()` already waits after volume creation.

  If the wait fails, deletion is still attempted as a best-effort
  fallback.

  ## Testing

  - `go build ./...` passes
  - `go test ./builder/openstack/...` passes
  - `go fmt` applied
